### PR TITLE
Move module-level comments prior to the import statements

### DIFF
--- a/client/src/Model.elm
+++ b/client/src/Model.elm
@@ -1,8 +1,4 @@
 module Model exposing (..)
-
-import Dict exposing (Dict)
-import Dict as D
-
 {-| This module includes all model-related part of OpenIRC.
 Top-level model consists of four fields: bufferMap, serverInfoMap, currentServerName, currentChannelName.
 
@@ -17,7 +13,11 @@ Top-level model consists of four fields: bufferMap, serverInfoMap, currentServer
 # Getters
 
 @docs getBuffer, getServerInfo, getNick, getNewChannelName, getServerBuffer
+
 -}
+
+import Dict exposing (Dict)
+import Dict as D
 
 {-| Server name is a string
 -}

--- a/client/src/Update.elm
+++ b/client/src/Update.elm
@@ -1,13 +1,4 @@
 module Update exposing (Msg(..), update)
-
-import String exposing (isEmpty, startsWith)
-import Dict exposing (Dict)
-import Dict as D
-import Task exposing (Task)
-import Dom.Scroll exposing (toBottom)
--- Local modules
-import Model exposing (..)
-
 {-| This module includes all update-related part of OpenIRC.
 
 # Definitions
@@ -22,6 +13,15 @@ import Model exposing (..)
 
 @docs updateBufferMap, updateNewChannelName, updateServerBuffer, isServerBuffer, isValidNewBuffer
 -}
+
+import String exposing (isEmpty, startsWith)
+import Dict exposing (Dict)
+import Dict as D
+import Task exposing (Task)
+import Dom.Scroll exposing (toBottom)
+-- Local modules
+import Model exposing (..)
+
 
 {-| Collection of all msg used inside OpenIRC.
 

--- a/client/src/View.elm
+++ b/client/src/View.elm
@@ -1,14 +1,4 @@
 module View exposing (view)
-
-import Html exposing (..)
-import Html.Events exposing (onSubmit, onInput, onClick)
-import Html.Attributes exposing (id, class, type_, placeholder, value, autocomplete)
-import Dict as D
-import Tuple exposing (second)
--- Local modules
-import Model exposing (..)
-import Update exposing (Msg(..))
-
 {-| This module includes all view of OpenIRC.
 
 # Top-level View
@@ -23,6 +13,15 @@ import Update exposing (Msg(..))
 
 @docs currentBufferDiv, currentBufferInfoDiv, logsList, newLineForm
 -}
+
+import Html exposing (..)
+import Html.Events exposing (onSubmit, onInput, onClick)
+import Html.Attributes exposing (id, class, type_, placeholder, value, autocomplete)
+import Dict as D
+import Tuple exposing (second)
+-- Local modules
+import Model exposing (..)
+import Update exposing (Msg(..))
 
 {-| Top-level view of OpenIRC. It consists of two components - `bufferListsDiv` showing information about all open
 buffer(sidebar), and `currentBufferDiv` showing information about the current buffer.


### PR DESCRIPTION
Sorry, I was too exhausted after writing all the comments and forgot to check if it builds. This commit only moves module-level comments to their correct position.